### PR TITLE
improve list, ellipsis fix in top10, project grouping

### DIFF
--- a/src/AppBundle/Resources/views/Project/show.html.twig
+++ b/src/AppBundle/Resources/views/Project/show.html.twig
@@ -84,7 +84,7 @@
             {% for commit in project_commits|slice(0,10) %}
                 <div class="ui segment attached">
                     <a href="{{ path('commit_show', {id: commit.id}) }}">{{ commit.revision|slice(0,8) }}</a>
-                    <span class="ellipsis" style="width:3em">{{ commit.commitMessage }}</span>
+                    <div class="ellipsis">{{ commit.commitMessage }}</div>
                     by {{ commit.authorName|default("unknown") }}
                     {% if commit.authorEmail %}&lt;{{ commit.authorEmail }}&gt;{% endif %}
                     <div style="float: right">{{ _.commit_status_button(commit) }}</div>

--- a/src/AppBundle/Resources/views/feed.html.twig
+++ b/src/AppBundle/Resources/views/feed.html.twig
@@ -1,14 +1,17 @@
 {% import 'AppBundle::macros.html.twig' as _ %}
 
 <table class="ui very basic collapsing celled table">
-    <tbody>
+    {% set last_project = '' %}
     {% for item in items %}
         {% set commit = item.commit %}
         <tr>
-            <td class="top aligned">
+            <td width="20%" class="top aligned">
+                {% if last_project != item.project.name %}
+                {% set last_project = item.project.name %}
                 <div class="ui ribbon label">
                     <a href="{{ path('project_show', {id: item.project.id}) }}">{{ item.project.name }}</a>
                 </div>
+                {% endif %}
                 <div>
                     {% if item.type == 'branch' %}
                         <i class="fork icon"></i>
@@ -25,33 +28,25 @@
                 </div>
             </td>
             <td>
-                <div>
-                    <img class="commit-gravatar" src="{{ gravatar(commit.authorEmail, 16) }}"
-                         alt="{{ commit.authorName }}">
-                    {{ commit.authorName }}
-                </div>
-                <div>{{ commit.commitMessage }}</div>
-            </td>
-            <td>
-                {% if commit.issues|length > 0 %}
+                <div class="ui right floated segment">
+                    {{ _.commit_status_button(commit) }}
+                    {% if commit.issues|length > 0 %}
                     {{ _.levels(commit) }}<br/>
-
-                    <i class="plug icon"></i>
-                    {% set groups = group_issues(commit.issues) %}
-                    {% for gadget,issues in groups.gadget %}
-                        {{ gadget }}
-                    {% endfor %}
-                {% endif %}
-            </td>
-            <td>
-                <div><i class="calendar icon"></i> {{ item.createdAt|date('H:i Y-m-d') }}</div>
+                    {% endif %}
+                </div>
+                <div class="ellipsis">"{{ commit.commitMessage }}"</div>
                 <div>
                     <a href="{{ path('commit_show', {id: commit.id}) }}">
                         <i class="github icon"></i>&nbsp;{{ commit.revision|slice(0, 8) }}
                     </a>
+                    <i class="calendar icon"></i> {{ item.createdAt|date('H:i Y-m-d') }}
+                    <img class="commit-gravatar" src="{{ gravatar(commit.authorEmail, 16) }}"
+                         alt="{{ commit.authorName }}">
+                    {{ commit.authorName }}
+                </div>
+                <div>
                 </div>
             </td>
-            <td class="bottom aligned">{{ _.commit_status_button(commit) }}</td>
         </tr>
     {% endfor %}
     </tbody>

--- a/src/AppBundle/Resources/views/feed.html.twig
+++ b/src/AppBundle/Resources/views/feed.html.twig
@@ -31,7 +31,7 @@
                 <div class="ui right floated segment">
                     {{ _.commit_status_button(commit) }}
                     {% if commit.issues|length > 0 %}
-                    {{ _.levels(commit) }}<br/>
+                    {{ _.levels(commit) }}
                     {% endif %}
                 </div>
                 <div class="ellipsis">"{{ commit.commitMessage }}"</div>


### PR DESCRIPTION
* fixes #172 
* group consecutive project lines in news feed
* improve column configuration in news feed
![simpspector ui improvements 1](https://cloud.githubusercontent.com/assets/259744/13905685/38d50a86-eec7-11e5-9a5c-56c6900152d2.png)
![simpspector ui improvements 2](https://cloud.githubusercontent.com/assets/259744/13905687/4041921c-eec7-11e5-9fd2-152d512ca75a.png)
